### PR TITLE
Add support for url parameter "time"

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -50,4 +50,12 @@
 		},
 		false
 	);
+
+	const timestamp = new URLSearchParams(
+		document.location.search.substring(1)
+	).get('time');
+	if (timestamp) {
+		document.getElementById('user-unix-time').value = timestamp;
+		document.getElementById('submit-user-unix-time').click();
+	}
 })();


### PR DESCRIPTION
This change allows you to visit the page with a URL parameter of "time",
e.g.
?time=1621428974

which will populate the form and the time will be displayed in a user
friendly manner.

Resolves #2